### PR TITLE
Cambio en algunos metodos de vec3.hh

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,7 +7,7 @@ set(CMAKE_BUILD_TYPE Debug) # Remove this line if you already have a build type 
 
 if(CMAKE_COMPILER_IS_GNUCXX)
     message("Adding code coverage flags")
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -mavx -fprofile-arcs -ftest-coverage")
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -mavx -mavx2 -fprofile-arcs -ftest-coverage")
 endif()
 
 include_directories(${RayTracer_SOURCE_DIR}/include)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,7 +7,7 @@ set(CMAKE_BUILD_TYPE Debug) # Remove this line if you already have a build type 
 
 if(CMAKE_COMPILER_IS_GNUCXX)
     message("Adding code coverage flags")
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fprofile-arcs -ftest-coverage")
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -mavx -fprofile-arcs -ftest-coverage")
 endif()
 
 include_directories(${RayTracer_SOURCE_DIR}/include)

--- a/include/vec3.hh
+++ b/include/vec3.hh
@@ -20,14 +20,23 @@ class vec3 {
         vec3 operator-() const { return vec3(-e[0], -e[1], -e[2]); }
         double operator[](int i) const { return e[i]; }
         double& operator[](int i) { return e[i]; }
-
+		
+		/*
         vec3& operator+=(const vec3 &v) {
             e[0] += v.e[0];
             e[1] += v.e[1];
             e[2] += v.e[2];
             return *this;
-        }
-
+        }*/
+		//Keylor
+		vec3& operator+=(const vec3 &v) {
+			__m256d a = _mm256_load_pd(e);
+			__m256d b = _mm256_load_pd(v.e);
+			__m256d result = _mm256_add_pd(a, b);
+			_mm256_store_pd(e, result);
+			return *this;
+		}
+		//Es mejor dejarla asi
         vec3& operator*=(const double t) {
             e[0] *= t;
             e[1] *= t;
@@ -180,7 +189,8 @@ inline vec3 cross(const vec3 &u, const vec3 &v) {
                 u.e[2] * v.e[0] - u.e[0] * v.e[2],
                 u.e[0] * v.e[1] - u.e[1] * v.e[0]);
 }*/
-//Keylor
+//Keylor y me ayude con Chagpt
+//Keylor ft Chagpt
 inline vec3 cross(const vec3 &u, const vec3 &v) {
     __m256d u_0 = _mm256_set1_pd(u.e[0]); 
     __m256d u_1 = _mm256_set1_pd(u.e[1]); 

--- a/include/vec3.hh
+++ b/include/vec3.hh
@@ -4,6 +4,7 @@
 #include <cmath>
 #include <iostream>
 #include <rtweekend.hh>
+#include <immintrin.h>
 
 using std::sqrt;
 
@@ -74,9 +75,21 @@ inline std::ostream& operator<<(std::ostream &out, const vec3 &v) {
     return out << v.e[0] << ' ' << v.e[1] << ' ' << v.e[2];
 }
 
+/*
 inline vec3 operator+(const vec3 &u, const vec3 &v) {
     return vec3(u.e[0] + v.e[0], u.e[1] + v.e[1], u.e[2] + v.e[2]);
+}*/
+
+//Keylor
+inline vec3 operator+(const vec3 &u, const vec3 &v) {
+    __m128d u_vec = _mm_loadu_pd(u.e);
+    __m128d v_vec = _mm_loadu_pd(v.e);
+    __m128d result_vec = _mm_add_pd(u_vec, v_vec);
+    double result[2];
+    _mm_storeu_pd(result, result_vec);
+    return vec3(result[0], result[1], u.e[2] + v.e[2]);
 }
+
 
 inline vec3 operator-(const vec3 &u, const vec3 &v) {
     return vec3(u.e[0] - v.e[0], u.e[1] - v.e[1], u.e[2] - v.e[2]);
@@ -86,9 +99,11 @@ inline vec3 operator*(const vec3 &u, const vec3 &v) {
     return vec3(u.e[0] * v.e[0], u.e[1] * v.e[1], u.e[2] * v.e[2]);
 }
 
+
 inline vec3 operator*(double t, const vec3 &v) {
     return vec3(t*v.e[0], t*v.e[1], t*v.e[2]);
 }
+
 
 inline vec3 operator*(const vec3 &v, double t) {
     return t * v;

--- a/include/vec3.hh
+++ b/include/vec3.hh
@@ -81,6 +81,7 @@ inline vec3 operator+(const vec3 &u, const vec3 &v) {
 }*/
 
 //Keylor
+//Mejora en 0.20 el tiempo
 inline vec3 operator+(const vec3 &u, const vec3 &v) {
     __m128d u_vec = _mm_loadu_pd(u.e);
     __m128d v_vec = _mm_loadu_pd(v.e);
@@ -90,25 +91,56 @@ inline vec3 operator+(const vec3 &u, const vec3 &v) {
     return vec3(result[0], result[1], u.e[2] + v.e[2]);
 }
 
-
+/*
 inline vec3 operator-(const vec3 &u, const vec3 &v) {
     return vec3(u.e[0] - v.e[0], u.e[1] - v.e[1], u.e[2] - v.e[2]);
-}
+}*/
 
+//Keylor
+inline vec3 operator-(const vec3 &u, const vec3 &v){
+	__m128d u_vec = _mm_loadu_pd(u.e);
+    __m128d v_vec = _mm_loadu_pd(v.e);
+    __m128d result_vec = _mm_sub_pd(u_vec, v_vec);
+    double result[2];
+    _mm_storeu_pd(result, result_vec);
+    return vec3(result[0], result[1], u.e[2] - v.e[2]);
+}
+/*
 inline vec3 operator*(const vec3 &u, const vec3 &v) {
     return vec3(u.e[0] * v.e[0], u.e[1] * v.e[1], u.e[2] * v.e[2]);
+}*/
+
+//Keylor
+//Es mejor dejar la funcion original, la SIMD lo hace más lento
+inline vec3 operator*(const vec3 &u, const vec3 &v) {
+	__m128d u_vec = _mm_loadu_pd(u.e);
+    __m128d v_vec = _mm_loadu_pd(v.e);
+    __m128d result_vec = _mm_mul_pd(u_vec, v_vec);
+    double result[2];
+    _mm_storeu_pd(result, result_vec);
+    return vec3(result[0], result[1], u.e[2] * v.e[2]);
 }
 
-
+//Keylor
+//Es mejor dejar la funcion original, la SIMD lo hace más lento
 inline vec3 operator*(double t, const vec3 &v) {
     return vec3(t*v.e[0], t*v.e[1], t*v.e[2]);
 }
+/*
+inline vec3 operator*(double t, const vec3 &v){
+	__m128d t_val = _mm_loadu_pd(&t);
+    __m128d v_vec = _mm_loadu_pd(v.e);
+    __m128d result_vec = _mm_mul_pd(t_val, v_vec);
+    double result[2];
+    _mm_storeu_pd(result, result_vec);
+    return vec3(result[0], result[1], t * v.e[2]);
+}*/
 
-
+//Mejor dejarla
 inline vec3 operator*(const vec3 &v, double t) {
     return t * v;
 }
-
+//Mejor dejarla
 inline vec3 operator/(vec3 v, double t) {
     return (1/t) * v;
 }


### PR DESCRIPTION
Se implementaron los métodos en SIMD, que generaban mayor ganancia en eficiencia en vec3.hh.
Algunos como: 
-+=
-suma
-resta
-multiplicacion
-cross
-dot

La mayor ganancia se dio cuando cambie solo a SIMD el método de suma, dando una ganancia de 0.40 en el tiempo, sin embargo las llamadas a los métodos seguía siendo de 16000.
Por lo que opte por seguir cambiando algunos métodos, tras varias pruebas, decidí cambiar otros más. Datos a tener en cuenta:
-Algunos métodos no los cambie porque generaban mayores perdidas o no presentaban cambio alguno
-Y lo principal es que con los cambios que hice, si bien el tiempo ganado llego a ser entre 0.40 y 0.20, las llamas se redujeron en 8 veces menos aproximadamente, siendo actualmente alrededor de 2000.

Hay que tener presente que de momento solo se han aplicado los cambios al archivo .hh, por lo que se espera que al cambiar el archivo vec3.cc, se llegue a tener aun más ganancias.